### PR TITLE
fix(ActionControllerMixin): Visibility of controller

### DIFF
--- a/lib/src/action_controller_mixin.dart
+++ b/lib/src/action_controller_mixin.dart
@@ -1,18 +1,19 @@
 import 'package:flutter/material.dart';
+
 import 'action_controller.dart';
 
 mixin ActionControllerMixin<T extends StatefulWidget> on State<T> {
-  late ActionController _controller;
+  late ActionController controller;
 
   @override
   void initState() {
-    _controller = ActionController();
+    controller = ActionController();
     super.initState();
   }
 
   @override
   void dispose() {
-    _controller.close();
+    controller.close();
     super.dispose();
   }
 }

--- a/lib/src/default_action_controller.dart
+++ b/lib/src/default_action_controller.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 
 import 'action_controller.dart';
+import 'action_controller_mixin.dart';
 
 class DefaultActionController extends StatefulWidget {
-
   const DefaultActionController({
     required this.child,
     this.broadcast = true,
@@ -18,26 +18,20 @@ class DefaultActionController extends StatefulWidget {
 
   static ActionController? of(BuildContext context) => context
       .findAncestorStateOfType<_DefaultActionControllerState>()
-      ?._controller;
+      ?.controller;
 
   @override
   _DefaultActionControllerState createState() =>
       _DefaultActionControllerState();
 }
 
-class _DefaultActionControllerState extends State<DefaultActionController> {
-  late ActionController _controller;
-
+class _DefaultActionControllerState extends State<DefaultActionController>
+    with ActionControllerMixin {
   @override
   void initState() {
     super.initState();
-    _controller = widget.broadcast ? ActionController.broadcast() : ActionController();
-  }
-
-  @override
-  void dispose() {
-    _controller.close();
-    super.dispose();
+    controller =
+        widget.broadcast ? ActionController.broadcast() : ActionController();
   }
 
   @override

--- a/lib/src/progress_builder.dart
+++ b/lib/src/progress_builder.dart
@@ -1,8 +1,9 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:progress_builder/progress_builder.dart';
+
 import 'action_controller.dart';
+import 'default_action_controller.dart';
 
 ///
 /// Builds a widget in the non-progress/loading state


### PR DESCRIPTION
`ActionControllerMixin` has a private controller, inaccessible from the class that uses the mixin. This bug makes mixin useless in terms of reducing boilerplate code. 