### PR TITLE
Migrate(Dart SDK): Bump to 2.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.1.4] - 20 Dec 2022
+* Bump Dart SDK minimum version constraint to 2.17.0
+* Add linter rule 'use_super_parameters'
+
 ## [1.1.3] - 4 Aug 2021
 * Properly handle the race condition when the widget is disposed while performing the action
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [1.1.4] - 20 Dec 2022
 * Bump Dart SDK minimum version constraint to 2.17.0
 * Add linter rule 'use_super_parameters'
+* Use super parameters wherever applicable
+* Organize imports
 
 ## [1.1.3] - 4 Aug 2021
 * Properly handle the race condition when the widget is disposed while performing the action

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -136,3 +136,4 @@ linter:
     - use_string_buffers
     - use_to_and_as_if_applicable
     - valid_regexps
+    - use_super_parameters

--- a/example/.metadata
+++ b/example/.metadata
@@ -1,10 +1,45 @@
 # This file tracks properties of this Flutter project.
 # Used by Flutter tool to assess capabilities and perform upgrades etc.
 #
-# This file should be version controlled and should not be manually edited.
+# This file should be version controlled.
 
 version:
-  revision: d79295af24c3ed621c33713ecda14ad196fd9c31
+  revision: b8f7f1f9869bb2d116aa6a70dbeac61000b52849
   channel: stable
 
 project_type: app
+
+# Tracks metadata for the flutter migrate command
+migration:
+  platforms:
+    - platform: root
+      create_revision: b8f7f1f9869bb2d116aa6a70dbeac61000b52849
+      base_revision: b8f7f1f9869bb2d116aa6a70dbeac61000b52849
+    - platform: android
+      create_revision: b8f7f1f9869bb2d116aa6a70dbeac61000b52849
+      base_revision: b8f7f1f9869bb2d116aa6a70dbeac61000b52849
+    - platform: ios
+      create_revision: b8f7f1f9869bb2d116aa6a70dbeac61000b52849
+      base_revision: b8f7f1f9869bb2d116aa6a70dbeac61000b52849
+    - platform: linux
+      create_revision: b8f7f1f9869bb2d116aa6a70dbeac61000b52849
+      base_revision: b8f7f1f9869bb2d116aa6a70dbeac61000b52849
+    - platform: macos
+      create_revision: b8f7f1f9869bb2d116aa6a70dbeac61000b52849
+      base_revision: b8f7f1f9869bb2d116aa6a70dbeac61000b52849
+    - platform: web
+      create_revision: b8f7f1f9869bb2d116aa6a70dbeac61000b52849
+      base_revision: b8f7f1f9869bb2d116aa6a70dbeac61000b52849
+    - platform: windows
+      create_revision: b8f7f1f9869bb2d116aa6a70dbeac61000b52849
+      base_revision: b8f7f1f9869bb2d116aa6a70dbeac61000b52849
+
+  # User provided section
+
+  # List of Local paths (relative to this file) that should be
+  # ignored by the migrate tool.
+  #
+  # Files that are not part of the templates will be ignored by default.
+  unmanaged_files:
+    - 'lib/main.dart'
+    - 'ios/Runner.xcodeproj/project.pbxproj'

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -5,7 +5,7 @@ import 'package:widget_with_codeview/widget_with_codeview.dart';
 void main() => runApp(const MyApp());
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) => MaterialApp(
@@ -25,7 +25,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatefulWidget {
-  const MyHomePage({Key? key}) : super(key: key);
+  const MyHomePage({super.key});
 
   @override
   _MyHomePageState createState() => _MyHomePageState();

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.1"
   charcode:
     dependency: transitive
     description:
@@ -35,14 +35,14 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   crypto:
     dependency: transitive
     description:
@@ -63,7 +63,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   ffi:
     dependency: transitive
     description:
@@ -134,7 +134,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   lints:
     dependency: transitive
     description:
@@ -148,21 +148,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.12"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   path_provider:
     dependency: transitive
     description:
@@ -232,7 +239,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.1"
+    version: "1.1.4"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -244,7 +251,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -265,21 +272,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.12"
   typed_data:
     dependency: transitive
     description:
@@ -335,7 +342,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   widget_with_codeview:
     dependency: "direct main"
     description:
@@ -358,5 +365,5 @@ packages:
     source: hosted
     version: "0.2.0"
 sdks:
-  dart: ">=2.13.0 <3.0.0"
+  dart: ">=2.17.0 <3.0.0"
   flutter: ">=2.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -5,10 +5,9 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
+import 'package:example/main.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import 'package:example/main.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {

--- a/lib/src/circular_progress_builder.dart
+++ b/lib/src/circular_progress_builder.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 
-import 'action_controller.dart';
 import 'progress_builder.dart';
 
 class CircularProgressBuilder extends ProgressBuilder {
@@ -11,44 +10,28 @@ class CircularProgressBuilder extends ProgressBuilder {
       CircularProgressIndicator.adaptive(value: value);
 
   const CircularProgressBuilder({
-    required ProgressChildWidgetBuilder builder,
-    ErrorCallback? onError,
-    ProgressAction? action,
-    VoidCallback? onDone,
-    VoidCallback? onStart,
-    VoidCallback? onSuccess,
-    ActionController? controller,
-    Key? key,
+    required super.builder,
+    super.onError,
+    super.action,
+    super.onDone,
+    super.onStart,
+    super.onSuccess,
+    super.controller,
+    super.key,
   }) : super(
-          action: action,
-          builder: builder,
-          onDone: onDone,
-          onError: onError,
-          onStart: onStart,
-          onSuccess: onSuccess,
           progressBuilder: _progressBuilder,
-          controller: controller,
-          key: key,
         );
 
   const CircularProgressBuilder.adaptive({
-    required ProgressChildWidgetBuilder builder,
-    ErrorCallback? onError,
-    ProgressAction? action,
-    VoidCallback? onDone,
-    VoidCallback? onStart,
-    VoidCallback? onSuccess,
-    ActionController? controller,
-    Key? key,
+    required super.builder,
+    super.onError,
+    super.action,
+    super.onDone,
+    super.onStart,
+    super.onSuccess,
+    super.controller,
+    super.key,
   }) : super(
-          action: action,
-          builder: builder,
-          onDone: onDone,
-          onError: onError,
-          onStart: onStart,
-          onSuccess: onSuccess,
           progressBuilder: _adaptiveProgressBuilder,
-          controller: controller,
-          key: key,
         );
 }

--- a/lib/src/default_action_controller.dart
+++ b/lib/src/default_action_controller.dart
@@ -7,8 +7,8 @@ class DefaultActionController extends StatefulWidget {
   const DefaultActionController({
     required this.child,
     this.broadcast = true,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   /// The widget below this widget in the tree.
   final Widget child;
@@ -31,7 +31,8 @@ class _DefaultActionControllerState extends State<DefaultActionController> {
   @override
   void initState() {
     super.initState();
-    _controller = widget.broadcast ? ActionController.broadcast() : ActionController();
+    _controller =
+        widget.broadcast ? ActionController.broadcast() : ActionController();
   }
 
   @override

--- a/lib/src/linear_progress_builder.dart
+++ b/lib/src/linear_progress_builder.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 
-import 'action_controller.dart';
 import 'progress_builder.dart';
 
 class LinearProgressBuilder extends ProgressBuilder {
@@ -8,23 +7,15 @@ class LinearProgressBuilder extends ProgressBuilder {
       LinearProgressIndicator(value: value);
 
   const LinearProgressBuilder({
-    required ProgressChildWidgetBuilder builder,
-    ErrorCallback? onError,
-    ProgressAction? action,
-    VoidCallback? onDone,
-    VoidCallback? onStart,
-    VoidCallback? onSuccess,
-    ActionController? controller,
-    Key? key,
+    required super.builder,
+    super.onError,
+    super.action,
+    super.onDone,
+    super.onStart,
+    super.onSuccess,
+    super.controller,
+    super.key,
   }) : super(
-          action: action,
-          builder: builder,
-          onDone: onDone,
-          onError: onError,
-          onStart: onStart,
-          onSuccess: onSuccess,
           progressBuilder: _progressBuilder,
-          controller: controller,
-          key: key,
         );
 }

--- a/lib/src/progress_builder.dart
+++ b/lib/src/progress_builder.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:progress_builder/progress_builder.dart';
-import 'action_controller.dart';
 
 ///
 /// Builds a widget in the non-progress/loading state
@@ -70,8 +69,8 @@ class ProgressBuilder extends StatefulWidget {
     this.onSuccess,
     this.onDone,
     this.onStart,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   _ProgressBuilderState createState() => _ProgressBuilderState();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,35 +21,28 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -80,21 +73,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.12"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -106,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -127,35 +127,28 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.13.0 <3.0.0"
+  dart: ">=2.17.0 <3.0.0"
   flutter: ">=1.17.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: progress_builder
 description: A simple wrapper for asynchronous actions with progress/loading indicators and error handling.
-version: 1.1.3
+version: 1.1.4
 homepage: https://github.com/apexlabs-ai/progress_builder
 
 environment:
-  sdk: ">=2.13.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
   flutter: ">=1.17.0"
 
 dependencies:


### PR DESCRIPTION
Major changes:

- Use super parameters introduced in Dart 2.17.0 to refactor and reduce code size.
- Add linter rules for quick fix suggestions and enabling dart migrate command.

Issues referenced:
Fix for #3